### PR TITLE
Add support for sending flashcards to db

### DIFF
--- a/database.js
+++ b/database.js
@@ -1,0 +1,34 @@
+const { MongoClient } = require('mongodb');
+require('dotenv').config();
+
+async function main() {
+    /**
+     * Connection URI. Update <username>, <password>, and <your-cluster-url> to reflect your cluster.
+     * See https://docs.mongodb.com/ecosystem/drivers/node/ for more details
+     */
+    const uri = process.env.MONGODB_URI;
+
+    console.log(uri);
+    const client = new MongoClient(uri);
+
+    try {
+        // Connect to the MongoDB cluster
+        await client.connect();
+
+        // Make the appropriate DB calls
+        await listDatabases(client);
+    } catch (e) {
+        console.error(e);
+    } finally {
+        await client.close();
+    }
+}
+
+async function listDatabases(client) {
+    databasesList = await client.db().admin().listDatabases();
+
+    console.log('Databases:');
+    databasesList.databases.forEach((db) => console.log(` - ${db.name}`));
+}
+
+main().catch(console.error);

--- a/database.js
+++ b/database.js
@@ -1,34 +1,28 @@
 const { MongoClient } = require('mongodb');
 require('dotenv').config();
 
-async function main() {
-    /**
-     * Connection URI. Update <username>, <password>, and <your-cluster-url> to reflect your cluster.
-     * See https://docs.mongodb.com/ecosystem/drivers/node/ for more details
-     */
+async function createDBClient() {
     const uri = process.env.MONGODB_URI;
-
-    console.log(uri);
     const client = new MongoClient(uri);
 
     try {
-        // Connect to the MongoDB cluster
         await client.connect();
-
-        // Make the appropriate DB calls
-        await listDatabases(client);
     } catch (e) {
         console.error(e);
-    } finally {
-        await client.close();
     }
+
+    return client;
 }
 
-async function listDatabases(client) {
-    databasesList = await client.db().admin().listDatabases();
-
-    console.log('Databases:');
-    databasesList.databases.forEach((db) => console.log(` - ${db.name}`));
+async function addFlashcards(client, flashCards) {
+    const result = await client
+        .db(process.env.DB_NAME)
+        .collection(process.env.COLLECTION_NAME)
+        .insertMany(flashCards);
+    return result;
 }
 
-main().catch(console.error);
+module.exports = {
+    createDBClient,
+    addFlashcards,
+};

--- a/database.js
+++ b/database.js
@@ -1,17 +1,28 @@
 const { MongoClient } = require('mongodb');
+const retry = require('retry');
+const { CustomError, UNABLE_TO_CONNECT_TO_DB } = require('./errors');
 require('dotenv').config();
 
 async function createDBClient() {
     const uri = process.env.MONGODB_URI;
     const client = new MongoClient(uri);
 
-    try {
-        await client.connect();
-    } catch (e) {
-        console.error(e);
-    }
-
-    return client;
+    return new Promise((resolve, reject) => {
+        const operation = retry.operation();
+        operation.attempt(async (currentAttempt) => {
+            try {
+                await client.connect();
+                resolve(client);
+            } catch (err) {
+                if (operation.retry(err)) {
+                    return;
+                }
+            }
+            reject(
+                new CustomError(UNABLE_TO_CONNECT_TO_DB, operation.mainError())
+            );
+        });
+    });
 }
 
 async function addFlashcards(client, flashCards) {

--- a/errors.js
+++ b/errors.js
@@ -13,6 +13,7 @@ const NO_MESSAGES_IN_QUEUE = 'No messages in queue';
 const FLASHCARD_GENERATION_FAILED = 'Flashcard generation failed';
 const UNABLE_TO_RETRIEVE_MESSAGES = 'Unable to retrieve messages';
 const UNABLE_TO_CONNECT_TO_DB = 'Unable to connect to database';
+const UNABLE_TO_ADD_FLASHCARDS_TO_DB = 'Unable to add flashcards to database';
 
 module.exports = {
     CustomError: CustomError,
@@ -24,4 +25,5 @@ module.exports = {
     FLASHCARD_GENERATION_FAILED: FLASHCARD_GENERATION_FAILED,
     UNABLE_TO_RETRIEVE_MESSAGES: UNABLE_TO_RETRIEVE_MESSAGES,
     UNABLE_TO_CONNECT_TO_DB: UNABLE_TO_CONNECT_TO_DB,
+    UNABLE_TO_ADD_FLASHCARDS_TO_DB: UNABLE_TO_ADD_FLASHCARDS_TO_DB,
 };

--- a/errors.js
+++ b/errors.js
@@ -12,6 +12,7 @@ const UNABLE_TO_DELETE_MESSAGE = 'Unable to delete message';
 const NO_MESSAGES_IN_QUEUE = 'No messages in queue';
 const FLASHCARD_GENERATION_FAILED = 'Flashcard generation failed';
 const UNABLE_TO_RETRIEVE_MESSAGES = 'Unable to retrieve messages';
+const UNABLE_TO_CONNECT_TO_DB = 'Unable to connect to database';
 
 module.exports = {
     CustomError: CustomError,
@@ -22,4 +23,5 @@ module.exports = {
     NO_MESSAGES_IN_QUEUE: NO_MESSAGES_IN_QUEUE,
     FLASHCARD_GENERATION_FAILED: FLASHCARD_GENERATION_FAILED,
     UNABLE_TO_RETRIEVE_MESSAGES: UNABLE_TO_RETRIEVE_MESSAGES,
+    UNABLE_TO_CONNECT_TO_DB: UNABLE_TO_CONNECT_TO_DB,
 };

--- a/example.js
+++ b/example.js
@@ -1,10 +1,15 @@
-const example1 =
+const inputTextExample1 =
     'In computing, plain text is a loose term for data (e.g. file contents) that represent only characters of readable material but not its graphical representation nor other objects (floating-point numbers, images, etc.). It may also include a limited number of "whitespace" characters that affect simple arrangement of text, such as spaces, line breaks, or tabulation characters. Plain text is different from formatted text, where style information is included; from structured text, where structural parts of the document such as paragraphs, sections, and the like are identified; and from binary files in which some portions must be interpreted as binary objects (encoded integers, real numbers, images, etc.) The term is sometimes used quite loosely, to mean files that contain only "readable" content (or just files with nothing that the speaker does not prefer). For example, that could exclude any indication of fonts or layout (such as markup, markdown, or even tabs); characters such as curly quotes, non-breaking spaces, soft hyphens, em dashes, and/or ligatures; or other things. In principle, plain text can be in any encoding, but occasionally the term is taken to imply ASCII. As Unicode-based encodings such as UTF-8 and UTF-16 become more common, that usage may be shrinking. Plain text is also sometimes used only to exclude "binary" files: those in which at least some parts of the file cannot be correctly interpreted via the character encoding in effect. For example, a file or string consisting of "hello" (in any encoding), following by 4 bytes that express a binary integer that is not a character, is a binary file. Converting a plain text file to a different character encoding does not change the meaning of the text, as long as the correct character encoding is used. However, converting a binary file to a different format may alter the interpretation of the non-textual data. According to The Unicode Standard: "Plain text is a pure sequence of character codes; plain Un-encoded text is therefore a sequence of Unicode character codes.In contrast, styled text, also known as rich text, is any text representation containing plain text plus added information such as a language identifier, font size, color, hypertext links, and so on. SGML, RTF, HTML, XML, and TeX are examples of rich text fully represented as plain text streams, interspersing plain text data with sequences of characters that represent the additional data structures."';
 
-const example2 =
+const inputTextExample2 =
     'German mathematicians Felix Klein and Georg Cantor are credited with putting forward the idea of an international congress of mathematicians in the 1890s. The University of Chicago, which had opened in 1892, organized an International Mathematical Congress at the Chicago World Fair in 1893, where Felix Klein participated as the official German representative. The first official International Congress of Mathematicians was held in Zurich in August 1897. The organizers included such prominent mathematicians as Luigi Cremona, Felix Klein, Gösta Mittag-Leffler, Andrey Markov, and others. The congress was attended by 208 mathematicians from 16 countries, including 12 from Russia and 7 from the US. Only four were women: Iginia Massarini, Vera von Schiff, Charlotte Scott, and Charlotte Wedell.[8]';
 
+const exampleFlashcard = {
+    front: 'What is the capital of France?',
+    back: 'Paris',
+};
 module.exports = {
-    example1: example1,
-    example2: example2,
+    example1: inputTextExample1,
+    example2: inputTextExample2,
+    exampleFlashcard: exampleFlashcard,
 };

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const {
     NO_MESSAGES_IN_QUEUE,
     FLASHCARD_GENERATION_FAILED,
 } = require('./errors');
+const { createDBClient, addFlashcards } = require('./database');
 
 const configuration = new Configuration({
     apiKey: process.env.AI_API_KEY,
@@ -140,8 +141,7 @@ const messageHandler = async (msg) => {
         flashcards = flashcards.slice(0, msgBody.cardCount);
 
     await deleteMessageWithRetries(msg.ReceiptHandle);
-    // TODO send flashcards to database
-    console.log(flashcards);
+    await addFlashcards(dbClient, flashcards);
 };
 
 const errorHandler = (err) => {
@@ -149,7 +149,9 @@ const errorHandler = (err) => {
     console.error('DETAILS:', err.details);
 };
 
+let dbClient;
 const main = async () => {
+    dbClient = await createDBClient();
     while (true) {
         let message;
         try {

--- a/index.js
+++ b/index.js
@@ -152,6 +152,7 @@ const errorHandler = (err) => {
 let dbClient;
 const main = async () => {
     dbClient = await createDBClient();
+
     while (true) {
         let message;
         try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@aws-sdk/client-sqs": "^3.388.0",
                 "dotenv": "^16.3.1",
+                "mongodb": "^5.8.1",
                 "openai": "^3.3.0",
                 "retry": "^0.13.1"
             }
@@ -569,6 +570,15 @@
                 "tslib": "^2.3.1"
             }
         },
+        "node_modules/@mongodb-js/saslprep": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+            "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+            "optional": true,
+            "dependencies": {
+                "sparse-bitfield": "^3.0.3"
+            }
+        },
         "node_modules/@smithy/abort-controller": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.2.tgz",
@@ -1055,6 +1065,25 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/@types/node": {
+            "version": "20.5.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.6.tgz",
+            "integrity": "sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ=="
+        },
+        "node_modules/@types/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+        },
+        "node_modules/@types/whatwg-url": {
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+            "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/webidl-conversions": "*"
+            }
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1072,6 +1101,14 @@
             "version": "2.11.0",
             "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
             "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+        },
+        "node_modules/bson": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
+            "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
+            "engines": {
+                "node": ">=14.20.1"
+            }
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
@@ -1156,6 +1193,17 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/ip": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+        },
+        "node_modules/memory-pager": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+            "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+            "optional": true
+        },
         "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -1175,6 +1223,55 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/mongodb": {
+            "version": "5.8.1",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
+            "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
+            "dependencies": {
+                "bson": "^5.4.0",
+                "mongodb-connection-string-url": "^2.6.0",
+                "socks": "^2.7.1"
+            },
+            "engines": {
+                "node": ">=14.20.1"
+            },
+            "optionalDependencies": {
+                "@mongodb-js/saslprep": "^1.1.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/credential-providers": "^3.188.0",
+                "@mongodb-js/zstd": "^1.0.0",
+                "kerberos": "^1.0.0 || ^2.0.0",
+                "mongodb-client-encryption": ">=2.3.0 <3",
+                "snappy": "^7.2.2"
+            },
+            "peerDependenciesMeta": {
+                "@aws-sdk/credential-providers": {
+                    "optional": true
+                },
+                "@mongodb-js/zstd": {
+                    "optional": true
+                },
+                "kerberos": {
+                    "optional": true
+                },
+                "mongodb-client-encryption": {
+                    "optional": true
+                },
+                "snappy": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/mongodb-connection-string-url": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+            "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+            "dependencies": {
+                "@types/whatwg-url": "^8.2.1",
+                "whatwg-url": "^11.0.0"
+            }
+        },
         "node_modules/openai": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/openai/-/openai-3.3.0.tgz",
@@ -1182,6 +1279,14 @@
             "dependencies": {
                 "axios": "^0.26.0",
                 "form-data": "^4.0.0"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/retry": {
@@ -1192,10 +1297,52 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+            "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/socks": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
+            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "dependencies": {
+                "ip": "^2.0.0",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/sparse-bitfield": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+            "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+            "optional": true,
+            "dependencies": {
+                "memory-pager": "^1.0.2"
+            }
+        },
         "node_modules/strnum": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
             "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+        },
+        "node_modules/tr46": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+            "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+            "dependencies": {
+                "punycode": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/tslib": {
             "version": "2.6.1",
@@ -1208,6 +1355,26 @@
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "bin": {
                 "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+            "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+            "dependencies": {
+                "tr46": "^3.0.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@aws-sdk/client-sqs": "^3.388.0",
         "dotenv": "^16.3.1",
+        "mongodb": "^5.8.1",
         "openai": "^3.3.0",
         "retry": "^0.13.1"
     }

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,25 @@
+const retry = require('retry');
+const { CustomError } = require('./errors');
+
+const withRetries = ({ func, retries, err }) => {
+    return async (...args) => {
+        return new Promise((resolve, reject) => {
+            const operation = retry.operation({ retries: retries });
+            operation.attempt(async (currentAttempt) => {
+                try {
+                    const result = await func(...args);
+                    resolve(result);
+                } catch (err) {
+                    if (operation.retry(err)) {
+                        return;
+                    }
+                }
+                reject(new CustomError(err, operation.mainError()));
+            });
+        });
+    };
+};
+
+module.exports = {
+    withRetries,
+};


### PR DESCRIPTION
This adds logic to connect to the database and add generated cards to the database.

Some things I'd like to do in the next pull request are refactor the 'retries' logic to a decorator function so it isn't unnecessarily replicated so much and add 'jobId's to messages to identify the job for polling later on.